### PR TITLE
changing resolution disabled on stopped subscriber

### DIFF
--- a/app/src/main/java/com/ably/tracking/demo/subscriber/data/ably/AssetTracker.kt
+++ b/app/src/main/java/com/ably/tracking/demo/subscriber/data/ably/AssetTracker.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 
 class AssetTracker {
 
-    private lateinit var subscriber: Subscriber
+    private var subscriber: Subscriber? = null
 
     lateinit var trackableId: String
 
@@ -46,27 +46,29 @@ class AssetTracker {
             }
         )
 
-    fun observeTrackableState(): Flow<TrackableState> = subscriber.trackableStates
+    fun observeTrackableState(): Flow<TrackableState> = subscriber!!.trackableStates
 
-    fun observeTrackableLocation(): Flow<LocationUpdate> = subscriber.locations
+    fun observeTrackableLocation(): Flow<LocationUpdate> = subscriber!!.locations
 
-    fun observeResolution(): Flow<Resolution> = subscriber.resolutions
+    fun observeResolution(): Flow<Resolution> = subscriber!!.resolutions
 
     suspend fun setForegroundResolution() {
-        if (this::subscriber.isInitialized) {
+        subscriber?.let {
             Log.d("AssetTracker", "Setting foreground resolution")
-            subscriber.resolutionPreference(foregroundResolution)
+            it.resolutionPreference(foregroundResolution)
         }
     }
 
     suspend fun setBackgroundResolution() {
-        if (this::subscriber.isInitialized) {
+        subscriber?.let {
             Log.d("AssetTracker", "Setting background resolution")
-            subscriber.resolutionPreference(backgroundResolution)
+            it.resolutionPreference(backgroundResolution)
         }
     }
 
     suspend fun stopTracking() {
-        subscriber.stop()
+        Log.d("AssetTracker", "Stopping the subscriber")
+        subscriber?.stop()
+        subscriber = null
     }
 }


### PR DESCRIPTION
Changed subscriber reference to a nullable type to avoid changing resolution on the stopped state.
It was crashing when the order arrived, and the app was navigating to another screen. I probably avoided this crash earlier thanks to lucky timing when running on an emulator.